### PR TITLE
[update]消費アイテムを自由に使えるように

### DIFF
--- a/Assets/_Yajima/StoreAndStorage/Storage.cs
+++ b/Assets/_Yajima/StoreAndStorage/Storage.cs
@@ -96,6 +96,8 @@ public static class StorageData
     /// <param name="itemData">使ったアイテム</param>
     public static void ItemUse(ItemData itemData)
     {
+        if (!_possessCount.ContainsKey(itemData)) return;
+
         _possessCount[itemData]--;
         //アイテムの個数が0を下回ることはない
         if (_possessCount[itemData] <= 0) _possessCount[itemData] = 0;


### PR DESCRIPTION
消費アイテムを使ったときに保管庫に使った情報を通知してたが、アイテムを購入していることを前提にしていたところをそうじゃなくした
つまり普通に消費アイテムを使えるようにした